### PR TITLE
Fixes for compiling and using min threshold

### DIFF
--- a/Canny Edge Detect/Makefile
+++ b/Canny Edge Detect/Makefile
@@ -1,0 +1,6 @@
+
+main: main.cpp canny.cpp
+	g++ -I/usr/local/include/opencv4 $^ -o $@ -lopencv_core -lopencv_highgui -lopencv_imgproc -lopencv_imgcodecs
+
+clean:
+	rm main

--- a/Canny Edge Detect/canny.cpp
+++ b/Canny Edge Detect/canny.cpp
@@ -40,28 +40,30 @@ canny::canny(String filename)
             cout << filter[i][j] << " ";
         }
     }
-    grayscaled = Mat(img.toGrayScale()); //Grayscale the image
+    cout << endl;
+    grayscaled = Mat(toGrayScale()); //Grayscale the image
     gFiltered = Mat(useFilter(grayscaled, filter)); //Gaussian Filter
     sFiltered = Mat(sobel()); //Sobel Filter
 
     non = Mat(nonMaxSupp()); //Non-Maxima Suppression
-    thres = Mat(threshold(non, 20, 40)); //Double Threshold and Finalize
-	
-	namedWindow("Original");  
+    thres = Mat(threshold(non, 30, 50)); //Double Threshold and Finalize
+
+    namedWindow("Original");
     namedWindow("GrayScaled");
     namedWindow("Gaussian Blur");
     namedWindow("Sobel Filtered");
     namedWindow("Non-Maxima Supp.");
     namedWindow("Final");
 
-    imshow("Original", img);                  
+    imshow("Original", img);
     imshow("GrayScaled", grayscaled);
     imshow("Gaussian Blur", gFiltered);
     imshow("Sobel Filtered", sFiltered);
     imshow("Non-Maxima Supp.", non);
     imshow("Final", thres);
+    waitKey(0); // Waits for a key press to close the windows
 
-	}
+    }
 }
 
 Mat canny::toGrayScale()
@@ -271,7 +273,7 @@ Mat canny::threshold(Mat imgin,int low, int high)
                 {
                     for (int y = j-1; y<j+2; y++) 
                     {
-                        if(x <= 0 || y <= 0 || EdgeMat.rows || y > EdgeMat.cols) //Out of bounds
+                        if(x <= 0 || y <= 0 || x > EdgeMat.rows || y > EdgeMat.cols) //Out of bounds
                             continue;
                         else
                         {
@@ -281,7 +283,7 @@ Mat canny::threshold(Mat imgin,int low, int high)
                                 anyHigh = true;
                                 break;
                             }
-                            else if(EdgeMat.at<uchar>(x,y) <= high && EdgeMat.at<uchar>(x,y) >= low)
+                            else if(EdgeMat.at<uchar>(x,y) >= low)
                                 anyBetween = true;
                         }
                     }

--- a/Canny Edge Detect/main.cpp
+++ b/Canny Edge Detect/main.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 int main()
 {
-    cv::String filePath = "/Users/hasanakg/Desktop/stpietro.jpg"; //Filepath of input image
+    cv::String filePath = "../Sample Images/stpietro.jpg"; //Filepath of input image
     canny cny(filePath);
         
     return 0;

--- a/Other links.txt
+++ b/Other links.txt
@@ -1,0 +1,22 @@
+Lane Detection:
+
+https://www.hackster.io/kemfic/simple-lane-detection-c3db2f
+https://www.hackster.io/kemfic/curved-lane-detection-34f771
+
+https://github.com/amusi/awesome-lane-detection
+https://paperswithcode.com/task/lane-detection - Only machine learning
+
+https://towardsdatascience.com/tutorial-build-a-lane-detector-679fd8953132 - Using Python
+https://medium.com/@mrhwick/simple-lane-detection-with-opencv-bfeb6ae54ec0 - Using Python
+https://towardsdatascience.com/finding-lane-lines-simple-pipeline-for-lane-detection-d02b62e7572b - Using Python
+
+
+Canny:
+
+https://docs.opencv.org/3.4/da/d5c/tutorial_canny_detector.html
+http://www.pages.drexel.edu/~nk752/Research/cannyTut2.html
+
+Datasets:
+
+https://xingangpan.github.io/projects/CULane.html
+https://github.com/TuSimple/tusimple-benchmark/issues/3


### PR DESCRIPTION
- The code didn't compile due to using `img.toGrayScale()` instead of just `toGrayScale()`
- The minimum threshold was being effectively ignored due to a flawed check in the `if` at [canny.cpp#L274](https://github.com/hasanakg/Canny-Edge-Detector/blob/14371cc93ab3d9065c68c45ddb59b5d254293a71/Canny%20Edge%20Detect/canny.cpp#L274).
- Other minor adjustments include a Makefile to provide standard compilation, `waitKey` to keep the image output open until some key is pressed, relative file path, and removing an unnecessary verification.